### PR TITLE
Add euler to quat method

### DIFF
--- a/src/me/drton/jmavlib/conversion/RotationConversion.java
+++ b/src/me/drton/jmavlib/conversion/RotationConversion.java
@@ -28,4 +28,24 @@ public class RotationConversion {
                 Math.atan2(2.0 * (q[0] * q[3] + q[1] * q[2]), 1.0 - 2.0 * (q[2] * q[2] + q[3] * q[3])),
         };
     }
+
+    public static float[] quaternionByEulerAngles(float[] euler) {
+        double cosPhi_2 = Math.cos(euler[0] / 2.0);
+        double cosTheta_2 = Math.cos(euler[1] / 2.0);
+        double cosPsi_2 = Math.cos(euler[2] / 2.0);
+        double sinPhi_2 = Math.sin(euler[0] / 2.0);
+        double sinTheta_2 = Math.sin(euler[1] / 2.0);
+        double sinPsi_2 = Math.sin(euler[2] / 2.0);
+        return new float[]{
+                (float)(cosPhi_2 * cosTheta_2 * cosPsi_2 +
+                        sinPhi_2 * sinTheta_2 * sinPsi_2),
+                (float)(sinPhi_2 * cosTheta_2 * cosPsi_2 -
+                        cosPhi_2 * sinTheta_2 * sinPsi_2),
+                (float)(cosPhi_2 * sinTheta_2 * cosPsi_2 +
+                        sinPhi_2 * cosTheta_2 * sinPsi_2),
+                (float)(cosPhi_2 * cosTheta_2 * sinPsi_2 -
+                        sinPhi_2 * sinTheta_2 * cosPsi_2)
+        };
+    }
+
 }

--- a/src/me/drton/jmavlib/conversion/RotationConversion.java
+++ b/src/me/drton/jmavlib/conversion/RotationConversion.java
@@ -1,5 +1,7 @@
 package me.drton.jmavlib.conversion;
 
+import javax.vecmath.Vector3d;
+
 import static java.lang.Math.cos;
 import static java.lang.Math.sin;
 
@@ -29,13 +31,13 @@ public class RotationConversion {
         };
     }
 
-    public static float[] quaternionByEulerAngles(float[] euler) {
-        double cosPhi_2 = Math.cos(euler[0] / 2.0);
-        double cosTheta_2 = Math.cos(euler[1] / 2.0);
-        double cosPsi_2 = Math.cos(euler[2] / 2.0);
-        double sinPhi_2 = Math.sin(euler[0] / 2.0);
-        double sinTheta_2 = Math.sin(euler[1] / 2.0);
-        double sinPsi_2 = Math.sin(euler[2] / 2.0);
+    public static float[] quaternionByEulerAngles(Vector3d euler) {
+        double cosPhi_2 = Math.cos(euler.getX() / 2.0);
+        double cosTheta_2 = Math.cos(euler.getY() / 2.0);
+        double cosPsi_2 = Math.cos(euler.getZ() / 2.0);
+        double sinPhi_2 = Math.sin(euler.getX() / 2.0);
+        double sinTheta_2 = Math.sin(euler.getY() / 2.0);
+        double sinPsi_2 = Math.sin(euler.getZ() / 2.0);
         return new float[]{
                 (float)(cosPhi_2 * cosTheta_2 * cosPsi_2 +
                         sinPhi_2 * sinTheta_2 * sinPsi_2),

--- a/src/me/drton/jmavlib/conversion/RotationConversion.java
+++ b/src/me/drton/jmavlib/conversion/RotationConversion.java
@@ -31,14 +31,14 @@ public class RotationConversion {
         };
     }
 
-    public static float[] quaternionByEulerAngles(Vector3d euler) {
+    public static Float[] quaternionByEulerAngles(Vector3d euler) {
         double cosPhi_2 = Math.cos(euler.getX() / 2.0);
         double cosTheta_2 = Math.cos(euler.getY() / 2.0);
         double cosPsi_2 = Math.cos(euler.getZ() / 2.0);
         double sinPhi_2 = Math.sin(euler.getX() / 2.0);
         double sinTheta_2 = Math.sin(euler.getY() / 2.0);
         double sinPsi_2 = Math.sin(euler.getZ() / 2.0);
-        return new float[]{
+        return new Float[]{
                 (float)(cosPhi_2 * cosTheta_2 * cosPsi_2 +
                         sinPhi_2 * sinTheta_2 * sinPsi_2),
                 (float)(sinPhi_2 * cosTheta_2 * cosPsi_2 -


### PR DESCRIPTION
@bkueng I think applying this PR may fix the problem with https://github.com/PX4/jMAVSim/pull/33
But maybe not; it says this was already merged. Something else must be broken.

All I know is that I can checkout PX4/jMAVSim master and compile it with submodule kd0aij/jMAVlib addEulerToQuat, but using PX4/jMAVlib master results in compilation errors.
