### PR TITLE
Fix handling of "<extensions/>" in mavlink schema.

### DIFF
--- a/src/me/drton/jmavlib/mavlink/MAVLinkMessageDefinition.java
+++ b/src/me/drton/jmavlib/mavlink/MAVLinkMessageDefinition.java
@@ -16,25 +16,36 @@ public class MAVLinkMessageDefinition {
     public final Map<String, MAVLinkField> fieldsByName;
     public final MAVLinkField[] fields;
     public final int payloadLength;
+    public final int payloadMinimumLength;
+    public final int extensionsIndex;
 
-    public MAVLinkMessageDefinition(int id, String name, MAVLinkField[] fields) {
+    public MAVLinkMessageDefinition(int id, String name, MAVLinkField[] fields, int extensionsIndex) {
         this.id = id;
         this.name = name;
         this.fields = fields;
+        this.extensionsIndex = extensionsIndex; // used to calculate correct extra CRC.
         this.fieldsByName = new HashMap<String, MAVLinkField>(fields.length);
+        int minlen = 0;
         int len = 0;
-        for (MAVLinkField field : fields) {
+        int size = fields.length;
+        for (int i = 0; i < size; i++) {
+            MAVLinkField field = fields[i];
             fieldsByName.put(field.name, field);
             field.offset = len;
             len += field.size;
+            if (i < extensionsIndex) {
+                minlen = len;
+            }
         }
+        this.payloadMinimumLength = minlen;
         this.payloadLength = len;
         this.extraCRC = calculateExtraCRC();
     }
 
     private byte calculateExtraCRC() {
         String extraCRCStr = name + " ";
-        for (MAVLinkField field : fields) {
+        for (int i = 0; i < extensionsIndex; i++) {
+            MAVLinkField field = fields[i];
             extraCRCStr += field.type.ctype + " " + field.name + " ";
             if (field.isArray()) {
                 extraCRCStr += (char) field.arraySize;


### PR DESCRIPTION
The <extensions/> tag is used in SERVO_OUTPUT_RAW.  Without this fix jMAVSum spews crc checksum errors on this message, and sends wrong checksum to qgc.