### PR TITLE
MAVLinkStream: handle EOS

### DIFF
--- a/src/me/drton/jmavlib/mavlink/MAVLinkStream.java
+++ b/src/me/drton/jmavlib/mavlink/MAVLinkStream.java
@@ -68,8 +68,11 @@ public class MAVLinkStream {
                     throw ioe;
                 }
                 buffer.flip();
-                if (n <= 0) {
+                if (n == 0) {
                     return null;
+                }
+                if (n == -1) { // -1 means End of Stream (i.e. the other side closed the socket)
+                    throw new IOException("End of Stream");
                 }
             }
         }


### PR DESCRIPTION
When the other end of the TCP connection was closed, in most cases an
Exception was thrown, but not always. In these cases read() returned -1,
meaning End of Stream. We now raise an IOException so the upper layers
will handle it accordingly.