### PR TITLE
mavlink: re-use sequence for forwarded messages

### DIFF
--- a/src/me/drton/jmavlib/mavlink/MAVLinkMessage.java
+++ b/src/me/drton/jmavlib/mavlink/MAVLinkMessage.java
@@ -21,7 +21,7 @@ public class MAVLinkMessage {
     public final int msgID;
     private final byte[] payload;
     private final ByteBuffer payloadBB;
-    private byte sequence = 0;
+    public byte sequence = 0;
     private byte compatFlags = 0; // mavlink 2 only
     private byte incompatFlags = 0; // mavlink 2 only
     public final int systemID;
@@ -30,6 +30,7 @@ public class MAVLinkMessage {
     private Charset charset = Charset.forName("latin1");
     public int protocolVersion = 1;
     private boolean signingEnabled = false; // not fully supported, this is only for msg length
+    public boolean forwarded = false; // message is forwarded and we should not change the sequence number
 
     /**
      * Create empty message by message ID (for filling and sending)
@@ -163,8 +164,7 @@ public class MAVLinkMessage {
         }
     }
 
-    public ByteBuffer encode(byte sequence) {
-        this.sequence = sequence;
+    public ByteBuffer encode() {
         ByteBuffer buf = ByteBuffer.allocate(payload.length + getNonPayloadLength());
         buf.order(schema.getByteOrder());
         if (protocolVersion == 2) {
@@ -177,7 +177,7 @@ public class MAVLinkMessage {
             buf.put((byte) 0); // incompatFlags
             buf.put((byte) 0); // compatFlags
         }
-        buf.put(sequence);
+        buf.put(this.sequence);
         buf.put((byte) systemID);
         buf.put((byte) componentID);
         if (protocolVersion == 2) {

--- a/src/me/drton/jmavlib/mavlink/MAVLinkStream.java
+++ b/src/me/drton/jmavlib/mavlink/MAVLinkStream.java
@@ -33,7 +33,12 @@ public class MAVLinkStream {
      * @throws IOException on IO error
      */
     public void write(MAVLinkMessage msg) throws IOException {
-        channel.write(msg.encode(txSeq++));
+        if (msg.forwarded) {
+            channel.write(msg.encode());
+        } else {
+            msg.sequence = txSeq++;
+            channel.write(msg.encode());
+        }
     }
 
     /**

--- a/src/me/drton/jmavlib/mavlink/MAVLinkStream.java
+++ b/src/me/drton/jmavlib/mavlink/MAVLinkStream.java
@@ -33,12 +33,10 @@ public class MAVLinkStream {
      * @throws IOException on IO error
      */
     public void write(MAVLinkMessage msg) throws IOException {
-        if (msg.forwarded) {
-            channel.write(msg.encode());
-        } else {
+        if (!msg.forwarded) {
             msg.sequence = txSeq++;
-            channel.write(msg.encode());
         }
+        channel.write(msg.encode());
     }
 
     /**


### PR DESCRIPTION
When we forward a MAVLink message we should not change the sequence number. With this change we are doing that and avoid confusing PX4 which has to assume messages were dropped if the sequence number is not correctly increasing.

Thanks to @JonasVautherin who helped with this.